### PR TITLE
Fix errors

### DIFF
--- a/src/cyberleague/client/ui/test.cljs
+++ b/src/cyberleague/client/ui/test.cljs
@@ -7,8 +7,10 @@
   (when match
     [:div.test
      ;; match/info contains error information if there is an error
-     (if (:match/info match)
-       [:p (:match/info match)]
+     (if (:match/error match)
+       [:<>
+        [:p "Error: " (:match/error match)]
+        [:p "Info: " (:match/info match)]]
        [:<>
         [:p
          (cond

--- a/src/cyberleague/coordinator/test_bot.clj
+++ b/src/cyberleague/coordinator/test_bot.clj
@@ -30,5 +30,5 @@
                      :bot/name "Them"}]
        :match/moves (result :game.result/history)
        :winner (result :game.result/winner)
-       :match/error (result :game.result/error)
+       :match/error (or (:game.result/error result) (result :error))
        :match/info (result :info)})))


### PR DESCRIPTION
When an illegal move or other engine error occurred there was no :results/info generated and the browser crashed. 