### PR TITLE
Set up CLI to release on pushed tags starting with v

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,36 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install Leiningen
+        uses: DeLaGuardo/setup-clojure@13.1
+        with:
+          lein: latest
+
+      - name: Build CLI uberjar
+        run: |
+          lein with-profile uberjar-cli uberjar
+          mv target/cyberleague-*-standalone.jar target/cyberleague.jar
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/cyberleague.jar


### PR DESCRIPTION
If a tag starts with `v` GitHub Actions will build the CLI and attach cyberleague.jar to the Release page, where people can download the .jar version of the CLI